### PR TITLE
Remove '>' from bash pip install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Build on top of [FastUI](https://github.com/pydantic/FastUI) and [LangChain Core
 ## Usage
 
 ```bash
-> pip install fastui-chat
+pip install fastui-chat
 ```
 
 ```python

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ app.start_with_uvicorn()
 ## Development Setup
 
 ```bash
-> git clone https://github.com/shroominic/fastui-chat.git && cd fastui-chat
+git clone https://github.com/shroominic/fastui-chat.git && cd fastui-chat
 
-> ./dev-install.sh
+./dev-install.sh
 ```
 
 ## TODO


### PR DESCRIPTION
the '>' in the bash command was making it so that you could not copy and paste the command directly into the terminal and run it.